### PR TITLE
call layout() after changing slide

### DIFF
--- a/coursemod/coursemod.js
+++ b/coursemod/coursemod.js
@@ -102,5 +102,6 @@
             toggleCourseView(config.coursemod.shown);
         }
         updateNotes(currentSlide);
+	Reveal.layout();
     } );
 }).call(this);


### PR DESCRIPTION
When slide A having data-coursemod-shown=false is made visible, and slide B having =true comes immediately afterwards, HTML elements in B are kept in false-like size and are not resized when B is made visible, thus frequently getting cropped off slide limits. Added Reveal.layout() at end of slidechanged event listener, seems to fix it.
