### PR TITLE
change C hotkey for V

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ coursemod: {
 ###Overriding the shown config
 You can override the `shown` parameter on a slide to slide basis. You just have to add `data-coursemod-shown = "true"` (or `false`) to the slide (`<section>`) you want to override and it will be done.
 ##Usage in presentation
-If you want to toggle the coursemode, I have also added an event to the `c` key. so pressing `c` with the plugin enabled will show or hide the notes view.
+If you want to toggle the coursemode, I have also added an event to the `V` key. so pressing `V` with the plugin enabled will show or hide the notes view.

--- a/coursemod/coursemod.js
+++ b/coursemod/coursemod.js
@@ -87,7 +87,7 @@
 
     Reveal.configure({
         keyboard: {
-            67: function() {
+            86: function() {
                 config.coursemod.shown = !config.coursemod.shown;
                 toggleCourseView(config.coursemod.shown)
             }


### PR DESCRIPTION
Chosen hotkey C conflicts with Blackboard plugin which has the same. Migrated to 'V' which seems not taken. Updated README.
