### PR TITLE
Call layout after keyboard shortcut

### DIFF
--- a/coursemod/coursemod.js
+++ b/coursemod/coursemod.js
@@ -5,7 +5,7 @@
 
     if (config === null || typeof config.coursemod === 'undefined' || !config.coursemod.enabled)
         return;
-    
+
     //disable when print-pdf is enabled
     if (window.location.href.indexOf('print-pdf') > -1)
         return;
@@ -89,7 +89,8 @@
         keyboard: {
             86: function() {
                 config.coursemod.shown = !config.coursemod.shown;
-                toggleCourseView(config.coursemod.shown)
+                toggleCourseView(config.coursemod.shown);
+		Reveal.layout();
             }
         }
     });


### PR DESCRIPTION
For presentations with "shown: false", update the layout when "v" is
pressed.  Without this, horizontal space is reduced but contents are
not resized.