### PR TITLE
Register key with addKeyBinding

### DIFF
--- a/coursemod/coursemod.js
+++ b/coursemod/coursemod.js
@@ -88,7 +88,7 @@
     Reveal.addKeyBinding({keyCode: 86, key: 'V', description: 'Courseware view'}, function() {
         config.coursemod.shown = !config.coursemod.shown;
         toggleCourseView(config.coursemod.shown);
-	Reveal.layout();
+        Reveal.layout();
     });
 
     Reveal.addEventListener( 'slidechanged', function( event ) {

--- a/coursemod/coursemod.js
+++ b/coursemod/coursemod.js
@@ -85,16 +85,11 @@
         toggleCourseView(slideOverride);
     }
 
-    Reveal.configure({
-        keyboard: {
-            86: function() {
-                config.coursemod.shown = !config.coursemod.shown;
-                toggleCourseView(config.coursemod.shown);
-		Reveal.layout();
-            }
-        }
+    Reveal.addKeyBinding({keyCode: 86, key: 'V', description: 'Courseware view'}, function() {
+        config.coursemod.shown = !config.coursemod.shown;
+        toggleCourseView(config.coursemod.shown);
+	Reveal.layout();
     });
-    Reveal.registerKeyboardShortcut( 'V', 'Courseware view' );
 
     Reveal.addEventListener( 'slidechanged', function( event ) {
         var currentSlide = event.currentSlide;


### PR DESCRIPTION
The former keyboard configuration method overwrote previously registered keys of other plugins.
Thus, whether the key of another plugin would work or not, depended on the order of plugin activation, which is bad.